### PR TITLE
Use images.jax.org as PUBLIC_BASE_URL

### DIFF
--- a/.env
+++ b/.env
@@ -2,5 +2,5 @@
 # OMERO.web URL to load data. Needs to have omero.web.public enabled
 # since we don't login.
 # NB: the "PUBLIC_" prefix is sveltekit requirement for public vars
-PUBLIC_BASE_URL="https://idr.openmicroscopy.org"
+PUBLIC_BASE_URL="https://images.jax.org"
 # PUBLIC_BASE_URL="http://localhost:4080"


### PR DESCRIPTION
Testing... (NB: images.jax.org doesn't have OMERO.figure installed, so images won't render just yet)

EDIT: fails due to CORS errors.